### PR TITLE
Avoid race condition between calling getResponse and the actuall response arriving

### DIFF
--- a/src/main/java/org/edgexfoundry/mqtt/MqttDriver.java
+++ b/src/main/java/org/edgexfoundry/mqtt/MqttDriver.java
@@ -403,12 +403,16 @@ public class MqttDriver {
     } else {
       msg = new CmdMsg(attribute.getName(), operation);
     }
+
+    responseProcessor.addResponse(msg.getUuid());
+
     if (sendor.sendMessage(gson.toJson(msg).getBytes())) {
       logger.info(
           operation + " request for " + attribute.getName() + " sent to: " + addressable.getName());
       logger.debug("Outgoing message:  " + gson.toJson(msg));
       return msg.getUuid();
     } else {
+      responseProcessor.removeResponse(msg.getUuid());
       String errorMsg = "Problem sending command for attribute (" + attribute.getName()
           + ") message to addressable:  " + addressable.getName();
       logger.error(errorMsg);

--- a/src/main/java/org/edgexfoundry/mqtt/messaging/CommandResponseMessageProcessor.java
+++ b/src/main/java/org/edgexfoundry/mqtt/messaging/CommandResponseMessageProcessor.java
@@ -61,7 +61,6 @@ public class CommandResponseMessageProcessor {
   }
 
   public String getResponse(String uuid) {
-    addResponse(uuid);
     logger.debug("Response registered for uuid: " + uuid);
     try {
       while (NO_RESP.equals(responses.get(uuid))) {
@@ -76,8 +75,12 @@ public class CommandResponseMessageProcessor {
     }
   }
 
-  private void addResponse(String uuid) {
+  public void addResponse(String uuid) {
     responses.put(uuid, NO_RESP);
+  }
+
+  public void removeResponse(String uuid) {
+    responses.remove(uuid);
   }
 
   // get the data out of the MQTT JSON message.


### PR DESCRIPTION
NO_RESP was being added to the ConcurrentHashMap with the uuid of the expected response after sending the message. When using a local MQTT broker and responding programmatically, sometimes the response would arrive before getResponse was called. getResponse would overwrite the received response by writting NO_RESP, hence missing the actual response. 
This is probably not noticeable when using a cloud broker, but happens often with a local broker.
